### PR TITLE
feat(materials-ui): integrate with redactions log to complete redaction journey

### DIFF
--- a/materials_ui/src/app.tsx
+++ b/materials_ui/src/app.tsx
@@ -8,16 +8,9 @@ export const App = () => {
   const { instance, accounts } = useMsal();
 
   useEffect(() => {
-    instance.handleRedirectPromise().then((response) => {
-      if (response && response.account) {
-        instance.setActiveAccount(response.account);
-      }
-
-      const activeAccount = instance.getActiveAccount();
-      if (!activeAccount && accounts.length === 0) {
-        instance.loginRedirect(loginRequest).catch(console.error);
-      }
-    });
+    if (!instance.getActiveAccount() && accounts.length === 0) {
+      instance.loginRedirect(loginRequest).catch(console.error);
+    }
   }, [instance, accounts]);
 
   const account = instance.getActiveAccount() || accounts[0];

--- a/materials_ui/src/caseWorkApp/components/utils/getData.ts
+++ b/materials_ui/src/caseWorkApp/components/utils/getData.ts
@@ -20,11 +20,14 @@ export const useAxiosInstances = () => {
     return instance;
   };
 
+  const redactionLogScope = import.meta.env.VITE_REDACTION_LOG_SCOPE;
+
   return {
     axiosInstance: createInstance(import.meta.env.VITE_POLARIS_GATEWAY_URL),
-    redactionLogAxios: createInstance(import.meta.env.VITE_REDACTION_LOG_URL, [
-      import.meta.env.VITE_REDACTION_LOG_SCOPE
-    ])
+    redactionLogAxios: createInstance(
+      import.meta.env.VITE_REDACTION_LOG_URL,
+      redactionLogScope ? [redactionLogScope] : undefined
+    )
   };
 };
 
@@ -70,9 +73,7 @@ export const getPdfFiles = async (p: {
 
 export const getLookups = async (p: { axiosInstance: AxiosInstance }) => {
   try {
-    const response = await p.axiosInstance.get(
-      `${import.meta.env.VITE_REDACTION_LOG_URL}/api/lookUps`
-    );
+    const response = await p.axiosInstance.get('/api/lookUps');
     return response.data;
   } catch (error) {
     if (error instanceof AxiosError)
@@ -85,10 +86,7 @@ export const postRedactionLog = async (p: {
   data: RedactionLogData;
 }) => {
   try {
-    const response = await p.axiosInstance.post(
-      `${import.meta.env.VITE_REDACTION_LOG_URL}/api/redactionLogs`,
-      p.data
-    );
+    const response = await p.axiosInstance.post('/api/redactionLogs', p.data);
     return response.data;
   } catch (error) {
     if (error instanceof AxiosError)

--- a/materials_ui/src/caseWorkApp/pages/ReviewAndRedactPage/ReviewAndRedactPage.tsx
+++ b/materials_ui/src/caseWorkApp/pages/ReviewAndRedactPage/ReviewAndRedactPage.tsx
@@ -29,7 +29,7 @@ import { RedactionLogModal } from '../../../materials_components/RedactionLog/Re
 import type { SearchTermResultType } from '../../../schemas/documents';
 import { getDocumentIdWithoutPrefix } from '../../../utils/string';
 import { Tabs } from '../../components/tabs';
-import { getLookups, useAxiosInstance } from '../../components/utils/getData';
+import { getLookups, useAxiosInstances } from '../../components/utils/getData';
 import { TLookupsResponse } from '../../types/redaction';
 import { CloseTabUnsavedRedactionsModal } from './CloseTabUnsavedRedactionsModal';
 import { UnsavedRedactionsModal } from './UnsavedRedactionsModal';
@@ -87,12 +87,13 @@ export const ReviewAndRedactPage = () => {
   >();
   const [documents, setDocuments] = useState<TDocument[] | null | undefined>();
   const documentsRef = useRef<TDocument[] | null | undefined>(undefined);
+
   useEffect(() => {
     documentsRef.current = documents;
   }, [documents]);
 
   useEffect(() => {
-    window.addEventListener('beforeunload', () => {
+    const onBeforeUnload = () => {
       documentsRef.current?.forEach((document) => {
         if (document && caseId && urn)
           checkInDocumentFromAxiosInstance({
@@ -103,13 +104,16 @@ export const ReviewAndRedactPage = () => {
             versionId: document.versionId
           });
       });
-    });
+    };
+
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
   }, []);
 
   const [showRedactionLogModal, setShowRedactionLogModal] = useState(false);
   const [lookups, setLookups] = useState<TLookupsResponse>();
 
-  const axiosInstance = useAxiosInstance();
+  const { redactionLogAxios, axiosInstance } = useAxiosInstances();
 
   useEffect(() => {
     if (!caseId) return;
@@ -269,7 +273,7 @@ export const ReviewAndRedactPage = () => {
 
   useEffect(() => {
     if (showRedactionLogModal) {
-      getLookups({ axiosInstance: axiosInstance }).then((data) => {
+      getLookups({ axiosInstance: redactionLogAxios }).then((data) => {
         setLookups(data);
       });
     }

--- a/materials_ui/src/caseWorkApp/types/redaction.ts
+++ b/materials_ui/src/caseWorkApp/types/redaction.ts
@@ -3,7 +3,7 @@ type TChildren = [{ id: string; name: string }];
 export type TLookupsResponse = {
   areas: { id: string; name: string; children: TChildren }[];
   divisions: { id: string; name: string; children: TChildren }[];
-  documentTypes: { id: string; name: string; children: TChildren }[];
+  documentTypes: { id: string, cmsDocTypeId: string; name: string; children: TChildren }[];
   investigatingAgencies: { id: string; name: string; children: TChildren }[];
   missedRedactions: {
     isDeletedPage: boolean;

--- a/materials_ui/src/constants/chargeStatus.ts
+++ b/materials_ui/src/constants/chargeStatus.ts
@@ -1,0 +1,9 @@
+export enum ChargeStatusCode {
+  PreCharge = 1,
+  PostCharge = 2
+}
+
+export const CHARGE_STATUS_SELECT_OPTIONS = [
+  { id: String(ChargeStatusCode.PreCharge), name: 'Pre-charge' },
+  { id: String(ChargeStatusCode.PostCharge), name: 'Post-charge' }
+];

--- a/materials_ui/src/index.tsx
+++ b/materials_ui/src/index.tsx
@@ -20,29 +20,34 @@ if (import.meta.env.DEV && !import.meta.env.VITE_E2E) {
   });
 }
 
-const pca = new PublicClientApplication(msalConfig);
+const msalInstance = new PublicClientApplication(msalConfig);
 
-pca.initialize().then(() => {
-  ReactDOM.createRoot(document.getElementById('root')!).render(
-    <MsalProvider instance={pca}>
-      <SWRConfig
-        value={{
-          errorRetryCount: 0,
-          revalidateOnFocus: false,
-          shouldRetryOnError: false
-        }}
+await msalInstance.initialize();
+const redirectResult = await msalInstance.handleRedirectPromise();
+
+if (redirectResult?.account) {
+  msalInstance.setActiveAccount(redirectResult.account);
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <MsalProvider instance={msalInstance}>
+    <SWRConfig
+      value={{
+        errorRetryCount: 0,
+        revalidateOnFocus: false,
+        shouldRetryOnError: false
+      }}
+    >
+      <BrowserRouter
+        basename={import.meta.env.BASE_URL}
+        future={{ v7_startTransition: false, v7_relativeSplatPath: false }}
       >
-        <BrowserRouter
-          basename={import.meta.env.BASE_URL}
-          future={{ v7_startTransition: false, v7_relativeSplatPath: false }}
-        >
-          <AppContextProvider>
-            <FilterProvider>
-              <App />
-            </FilterProvider>
-          </AppContextProvider>
-        </BrowserRouter>
-      </SWRConfig>
-    </MsalProvider>
-  );
-});
+        <AppContextProvider>
+          <FilterProvider>
+            <App />
+          </FilterProvider>
+        </AppContextProvider>
+      </BrowserRouter>
+    </SWRConfig>
+  </MsalProvider>
+);

--- a/materials_ui/src/materials_components/DocumentSelectAccordion/getters/getAccessTokenFromMsalInstance.ts
+++ b/materials_ui/src/materials_components/DocumentSelectAccordion/getters/getAccessTokenFromMsalInstance.ts
@@ -1,13 +1,27 @@
-import { IPublicClientApplication } from '@azure/msal-browser';
+import { IPublicClientApplication, InteractionRequiredAuthError } from '@azure/msal-browser';
 
 export const getAccessTokenFromMsalInstance = async (
   msalInstance: IPublicClientApplication,
   scopes?: string[]
 ) => {
-  const tokenResponse = await msalInstance.acquireTokenSilent({
-    scopes: scopes || [import.meta.env.VITE_POLARIS_GATEWAY_SCOPE],
-    account: msalInstance.getActiveAccount()!
-  });
+  const account = msalInstance.getActiveAccount();
 
-  return tokenResponse.accessToken;
+  try {
+    const tokenResponse = await msalInstance.acquireTokenSilent({
+      scopes: scopes || [import.meta.env.VITE_POLARIS_GATEWAY_SCOPE],
+      account: account!,
+    });
+
+    return tokenResponse.accessToken;
+  } catch (error) {
+    if (error instanceof InteractionRequiredAuthError) {
+      const tokenResponse = await msalInstance.acquireTokenPopup({
+        scopes: scopes || [import.meta.env.VITE_POLARIS_GATEWAY_SCOPE],
+        account: account!
+      });
+      return tokenResponse.accessToken;
+    }
+
+    throw error;
+  }
 };

--- a/materials_ui/src/materials_components/DocumentTabPanel/DocumentTabPanel.tsx
+++ b/materials_ui/src/materials_components/DocumentTabPanel/DocumentTabPanel.tsx
@@ -1,10 +1,9 @@
 import axios from 'axios';
 import { useEffect, useRef, useState } from 'react';
-import { getPdfFiles } from '../../caseWorkApp/components/utils/getData';
+import { getLookups, getPdfFiles, useAxiosInstances } from '../../caseWorkApp/components/utils/getData';
 import { Banner } from '../../components';
 import { LoadingSpinner } from '../../components/LoadingSpinner/LoadingSpinner';
 import { CaseworkPdfRedactorWrapper } from '../CaseworkPdfRedactorWrapper/CaseworkPdfRedactorWrapper';
-import { useAxiosInstance } from '../DocumentSelectAccordion/getters/getAxiosInstance';
 import { TDocument } from '../DocumentSelectAccordion/getters/getDocumentList';
 import { DocumentViewportArea } from '../documenViewportArea';
 import { TRedactionType } from '../PdfRedactor/PdfRedactionTypeForm';
@@ -12,6 +11,7 @@ import { TRedaction } from '../PdfRedactor/utils/coordUtils';
 import { TMode } from '../PdfRedactor/utils/modeUtils';
 import type { TSearchHighlight } from '../PdfRedactor/utils/searchHighlightUtils';
 import { RedactionLogModal } from '../RedactionLog/RedactionLogModal';
+import { TLookupsResponse } from '../../caseWorkApp/types/redaction';
 
 export type DocSearchContext = {
   searchTerm: string;
@@ -62,7 +62,7 @@ export const DocumentTabPanel = ({
   onFocusedSearchIndexChange,
   onBackToSearchResults
 }: DocumentTabPanelProps) => {
-  const axiosInstance = useAxiosInstance();
+  const { redactionLogAxios, axiosInstance } = useAxiosInstances();
 
   const [pdfFileUrl, setPdfFileUrl] = useState<string>('');
   const [status, setStatus] = useState<LoadStatus>('loading');
@@ -75,6 +75,8 @@ export const DocumentTabPanel = ({
   >();
   const [redactionLogModalData, setRedactionLogModalData] =
     useState<RedactionLogModalData>();
+  const [lookups, setLookups] = useState<TLookupsResponse>();
+
 
   useEffect(() => {
     const loadPdf = async () => {
@@ -115,11 +117,24 @@ export const DocumentTabPanel = ({
   }, [documentId, versionId, urn, caseId]);
   const [numOfDocumentPages, setNumOfDocumentPages] = useState(0);
 
+
+  useEffect(() => {
+    const loadLookups = async () => {
+      const data = await getLookups({ axiosInstance: redactionLogAxios });
+      if (data) {
+        setLookups(data);
+      }
+    };
+    loadLookups();
+  }, []);
+
+
   return (
     <div>
       {showRedactionLogModal && redactionLogModalData && (
         <RedactionLogModal
           urn={urn}
+          caseId={caseId}
           isOpen={showRedactionLogModal}
           onClose={() => {
             setShowRedactionLogModal(false);
@@ -129,6 +144,7 @@ export const DocumentTabPanel = ({
           redactions={redactionLogModalData.redactions}
           selectedRedactionTypes={redactionLogModalData.selectedRedactionTypes}
           activeDocument={document}
+          lookups={lookups}
           redactionSaveStatus={redactionSaveStatus}
         />
       )}

--- a/materials_ui/src/materials_components/RedactionLog/RedactionLogModal.tsx
+++ b/materials_ui/src/materials_components/RedactionLog/RedactionLogModal.tsx
@@ -1,4 +1,6 @@
+import { useMemo } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import { useCaseDetails } from '../../hooks/search/useCaseSearch';
 import {
   postRedactionLog,
   useAxiosInstances
@@ -12,6 +14,7 @@ import styles from './RedactionLogModal.module.scss';
 import { RedactionLogModalBody } from './RedactionLogModalBody';
 import { RedactionLogModalHeader } from './RedactionLogModalHeader';
 import { transformFormDataToApiFormat } from './utils/transformFormData';
+import { ChargeStatusCode } from '../../constants/chargeStatus';
 
 export type RedactionLogFormInputs = {
   underRedactionSelected: boolean;
@@ -23,7 +26,7 @@ export type RedactionLogFormInputs = {
   areasAndDivisionsId: string;
   businessUnitId: string;
   investigatingAgencyId: string;
-  chargeStatus: 'Pre-charge' | 'Post-charge';
+  chargeStatus: ChargeStatusCode;
   documentTypeId: string | number;
 
   category: 'under' | 'over' | null;
@@ -60,6 +63,7 @@ export const RedactionLogModal = ({
   urn,
   activeDocument,
   isOpen,
+  caseId,
   onClose,
   lookups,
   mode,
@@ -67,6 +71,24 @@ export const RedactionLogModal = ({
   selectedRedactionTypes,
   redactionSaveStatus
 }: RedactionLogModalProps) => {
+  const { data: caseDetailsResponse } = useCaseDetails({ urn });
+
+  const chargeStatusFromCase = useMemo((): ChargeStatusCode | undefined => {
+    if (!caseId || !caseDetailsResponse?.data) {
+      return undefined;
+    }
+
+    const row = caseDetailsResponse.data.find(({ id }) => id === caseId);
+
+    if (!row) {
+      return undefined;
+    }
+
+    return row.isCaseCharged
+      ? ChargeStatusCode.PostCharge
+      : ChargeStatusCode.PreCharge;
+  }, [caseId, caseDetailsResponse]);
+
   const policeCode = urn.substring(0, 2);
 
   const existingInvestigatingAgencyId = lookups?.ouCodeMapping.find(
@@ -86,7 +108,7 @@ export const RedactionLogModal = ({
       areasAndDivisionsId: '',
       businessUnitId: '',
       investigatingAgencyId: existingInvestigatingAgencyId || '',
-      chargeStatus: 'Pre-charge',
+      chargeStatus: chargeStatusFromCase ?? ChargeStatusCode.PreCharge,
       documentTypeId: activeDocument?.cmsDocType.documentTypeId || '',
       supportingNotes: ''
     }
@@ -141,6 +163,7 @@ export const RedactionLogModal = ({
           )}
 
           <RedactionLogModalHeader urn={urn} lookups={lookups} />
+
           <RedactionLogModalBody
             activeDocument={activeDocument}
             mode={mode}

--- a/materials_ui/src/materials_components/RedactionLog/RedactionLogModalHeader.tsx
+++ b/materials_ui/src/materials_components/RedactionLog/RedactionLogModalHeader.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { TLookupsResponse } from '../../caseWorkApp/types/redaction';
 import { Popover } from './Popover';
+import { CHARGE_STATUS_SELECT_OPTIONS } from '../../constants/chargeStatus';
 import { RedactionLogFormInputs } from './RedactionLogModal';
 import styles from './RedactionLogModal.module.scss';
 import { SelectDropdown } from './templates/Select';
@@ -16,12 +17,6 @@ export const RedactionLogModalHeader = ({
   const divisions = lookups?.divisions || [];
   const investigatingAgencies = lookups?.investigatingAgencies || [];
 
-  // TODO: Temp data for charge statuses - to be replaced with API data when available
-  const chargeStatuses = [
-    { id: 'Pre-charge', name: 'Pre-charge' },
-    { id: 'Post-charge', name: 'Post-charge' }
-  ];
-
   const areasAndDivisions = [...areas, ...divisions];
   const [selectedId, setSelectedId] = useState<string>('');
   const selectedItem = areasAndDivisions.find((item) => item.id === selectedId);
@@ -34,10 +29,15 @@ export const RedactionLogModalHeader = ({
     formState: { errors }
   } = useFormContext<RedactionLogFormInputs>();
 
+  const documentTypes = (lookups?.documentTypes ?? [])
+    .filter((dt) => dt.cmsDocTypeId !== '')
+    .map((dt) => ({ id: dt.cmsDocTypeId.toString(), name: dt.name }));
+
   if (errors.areasAndDivisionsId) {
     errors.areasAndDivisionsId.message =
       'Please enter valid CPS Area or Central Casework Division';
   }
+
   if (errors.businessUnitId) {
     errors.businessUnitId.message = 'Please enter valid CPS Business Unit';
   }
@@ -178,12 +178,13 @@ export const RedactionLogModalHeader = ({
               label="Charge Status: "
               id="charge-status-select"
               name={field.name}
-              options={chargeStatuses}
+              options={CHARGE_STATUS_SELECT_OPTIONS}
               value={field.value}
               onChange={(e) => field.onChange(e.target.value)}
             />
           )}
         />
+
         <Controller
           name="documentTypeId"
           control={control}
@@ -193,7 +194,7 @@ export const RedactionLogModalHeader = ({
               label="Document Type: "
               id="document-type-select"
               name={field.name}
-              options={lookups?.documentTypes || []}
+              options={documentTypes}
               value={field.value}
               onChange={(e) => field.onChange(e.target.value)}
             />

--- a/materials_ui/src/materials_components/RedactionLog/utils/transformFormData.ts
+++ b/materials_ui/src/materials_components/RedactionLog/utils/transformFormData.ts
@@ -92,7 +92,7 @@ export const transformFormDataToApiFormat = (
   );
 
   const documentType = lookups.documentTypes?.find(
-    (dt) => dt.id.toString() === formData.documentTypeId.toString()
+    (dt) => dt.cmsDocTypeId.toString() === formData.documentTypeId.toString()
   );
 
   const redactions = createRedactionsArray(
@@ -115,21 +115,21 @@ export const transformFormDataToApiFormat = (
       name: investigatingAgency?.name || ''
     },
     documentType: {
-      id: documentType?.id.toString() || formData.documentTypeId.toString(),
+      id: documentType?.cmsDocTypeId.toString() || formData.documentTypeId.toString(),
       name: documentType?.name || ''
     },
     redactions,
     notes: formData.supportingNotes,
-    chargeStatus: formData.chargeStatus === 'Pre-charge' ? 1 : 2,
+    chargeStatus: formData.chargeStatus,
     cmsValues: {
       originalFileName: activeDocument?.cmsOriginalFileName || '',
       documentId: activeDocument?.documentId
         ? activeDocument.documentId.replace(/^CMS-/, '')
         : 0,
-      documentType: activeDocument?.cmsDocType?.documentType || '',
+      documentType: documentType?.name || '',
       fileCreatedDate:
         activeDocument?.cmsFileCreatedDate || new Date().toISOString(),
-      documentTypeId: activeDocument?.cmsDocType?.documentTypeId || 0
+      documentTypeId: parseInt(formData.documentTypeId.toString())
     }
   };
 };

--- a/materials_ui/src/vite-env.d.ts
+++ b/materials_ui/src/vite-env.d.ts
@@ -1,2 +1,9 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-svgr/client" />
+
+interface ImportMetaEnv {
+ readonly VITE_REDACTION_LOG_SCOPE: string;
+ readonly VITE_POLARIS_GATEWAY_SCOPE: string;
+ readonly VITE_POLARIS_GATEWAY_URL: string;
+ readonly VITE_REDACTION_LOG_URL: string;
+}


### PR DESCRIPTION
[FCT2-7534](https://cpsgovuk.atlassian.net/browse/FCT2-7534)
- Configure redaction-log `axios` with VITE_REDACTION_LOG_URL; call `/api/lookUps` and `/api/redactionLogs` as paths on that client (no duplicated base in every call).
- Make VITE_REDACTION_LOG_SCOPE optional when creating the redaction client.
- Declare Vite env vars on `ImportMetaEnv` in `vite-env.d.ts`.
- Await `initialize` and `handleRedirectPromise` before the first render so MSAL is fully ready and any login redirect is finished before the app reads accounts or acquires tokens, avoiding a wrong first paint and auth races.
- Simplify App `useEffect`: drop duplicate redirect handling, only `loginRedirect` when unauthenticated.
- Harden `getAccessTokenFromMsalInstance` per documentation (e.g. `InteractionRequiredAuthError` handling per staged implementation).
- Register `beforeunload` with cleanup to avoid listener leaks
- Use CMS documentTypeId from lookUps endpoint to pre-fill documentType select field