### PR TITLE
fix: update search label copy

### DIFF
--- a/materials_ui/src/components/DocumentKeywordSearch/DocumentKeywordSearch.tsx
+++ b/materials_ui/src/components/DocumentKeywordSearch/DocumentKeywordSearch.tsx
@@ -164,7 +164,7 @@ export const DocumentKeywordSearch = ({
     <div style={{ marginBottom: '20px' }}>
       <SearchInput
         id="search-within-case"
-        label="Search within a case"
+        label="Search within material"
         onSearch={handleSearchSubmit}
         placeholder="Enter search term"
         hideButton={false}


### PR DESCRIPTION
Change Review and Redaction search label wording from "Search within a case" to "Search within material"