### PR TITLE
fix(redaction-log): resolve area/division by id only when mapping unit (fix wrong area when unit ids repeat)

### DIFF
--- a/materials_ui/src/materials_components/RedactionLog/utils/transformFormData.ts
+++ b/materials_ui/src/materials_components/RedactionLog/utils/transformFormData.ts
@@ -9,20 +9,14 @@ const findAreaAndUnit = (
   unitId: string
 ) => {
   for (const area of lookups.areas || []) {
-    if (
-      area.id === areaId ||
-      area.children?.some((child) => child.id === unitId)
-    ) {
+    if (area.id === areaId) {
       const unit = area.children?.find((child) => child.id === unitId);
       return { area, unit };
     }
   }
 
   for (const division of lookups.divisions || []) {
-    if (
-      division.id === areaId ||
-      division.children?.some((child) => child.id === unitId)
-    ) {
+    if (division.id === areaId) {
       const unit = division.children?.find((child) => child.id === unitId);
       return { area: division, unit };
     }


### PR DESCRIPTION
`findAreaAndUnit` previously treated a match as `area.id` === `areaId` OR any child had `unitId`. Unit ids (e.g. CCU as "4") repeat under every area, so the first area in the list was always chosen and the payload sent the wrong `areaDivisionName`.

Resolve the node by id only, then look up the unit under that area or division. Remove the ambiguous branch so the selected business unit lines up with `areasAndDivisionsId` and `businessUnitId`.