### PR TITLE
fix(redact): use polaris mappings endpoint to fetch full document type mappings list to mirror polaris ui

### DIFF
--- a/materials_ui/src/caseWorkApp/components/utils/getData.ts
+++ b/materials_ui/src/caseWorkApp/components/utils/getData.ts
@@ -70,6 +70,18 @@ export const getPdfFiles = async (p: {
   }
 };
 
+export const getDocumentTypeMappings = async (p: {
+  axiosInstance: AxiosInstance;
+}) => {
+  try {
+    const response = await p.axiosInstance.get('/api/polarisMappings');
+    return response.data;
+  } catch (error) {
+    if (error instanceof AxiosError)
+      console.error(`Error getting document type mappings: ${error.message}`);
+  }
+};
+
 export const getLookups = async (p: { axiosInstance: AxiosInstance }) => {
   try {
     const response = await p.axiosInstance.get('/api/lookUps');

--- a/materials_ui/src/materials_components/DocumentSelectAccordion/getters/getDocumentList.tsx
+++ b/materials_ui/src/materials_components/DocumentSelectAccordion/getters/getDocumentList.tsx
@@ -8,7 +8,7 @@ export const documentSchema = z.object({
   status: z.string(),
   cmsDocType: z.object({
     documentTypeId: z.number(),
-    documentType: z.string().nullish(),
+    documentType: z.string().nullable(),
     documentCategory: z.string()
   }),
   cmsOriginalFileName: z.string(),

--- a/materials_ui/src/materials_components/RedactionLog/RedactionLogModal.tsx
+++ b/materials_ui/src/materials_components/RedactionLog/RedactionLogModal.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import {
+  getDocumentTypeMappings,
   postRedactionLog,
   useAxiosInstances
 } from '../../caseWorkApp/components/utils/getData';
@@ -14,6 +15,10 @@ import { Modal } from './Modal';
 import styles from './RedactionLogModal.module.scss';
 import { RedactionLogModalBody } from './RedactionLogModalBody';
 import { RedactionLogModalHeader } from './RedactionLogModalHeader';
+import {
+  getDocumentTypeValueFromMappings,
+  type RedactionLogMappingData
+} from './utils/getDocumentTypeValueFromMappings';
 import { transformFormDataToApiFormat } from './utils/transformFormData';
 
 export type RedactionLogFormInputs = {
@@ -71,6 +76,8 @@ export const RedactionLogModal = ({
   selectedRedactionTypes = [],
   redactionSaveStatus
 }: RedactionLogModalProps) => {
+  const [documentTypeMappings, setDocumentTypeMappings] =
+    useState<RedactionLogMappingData | null>(null);
   const { data: caseDetailsResponse } = useCaseDetails({ urn });
 
   const chargeStatusFromCase = useMemo((): ChargeStatusCode | undefined => {
@@ -97,6 +104,19 @@ export const RedactionLogModal = ({
 
   const { redactionLogAxios } = useAxiosInstances();
 
+  useEffect(() => {
+    const loadDocumentTypeMappings = async () => {
+      const data = await getDocumentTypeMappings({
+        axiosInstance: redactionLogAxios
+      });
+      if (data) {
+        setDocumentTypeMappings(data);
+      }
+    };
+
+    loadDocumentTypeMappings();
+  }, []);
+
   const form = useForm<RedactionLogFormInputs>({
     defaultValues: {
       underRedactionSelected: false,
@@ -113,6 +133,33 @@ export const RedactionLogModal = ({
       supportingNotes: ''
     }
   });
+
+  useEffect(() => {
+    const cmsDocumentTypeId = activeDocument?.cmsDocType.documentTypeId;
+
+    if (cmsDocumentTypeId === undefined || cmsDocumentTypeId === null) {
+      return;
+    }
+
+    const documentTypeIdValue = getDocumentTypeValueFromMappings(
+      cmsDocumentTypeId,
+      documentTypeMappings
+    );
+
+    if (!documentTypeIdValue) {
+      return;
+    }
+
+    if (`${form.getValues('documentTypeId')}` === documentTypeIdValue) {
+      return;
+    }
+
+    form.setValue('documentTypeId', documentTypeIdValue, {
+      shouldDirty: false,
+      shouldTouch: false,
+      shouldValidate: false
+    });
+  }, [activeDocument?.cmsDocType.documentTypeId, documentTypeMappings, form]);
 
   const onSubmit = async (values: RedactionLogFormInputs) => {
     try {

--- a/materials_ui/src/materials_components/RedactionLog/RedactionLogModal.tsx
+++ b/materials_ui/src/materials_components/RedactionLog/RedactionLogModal.tsx
@@ -137,7 +137,7 @@ export const RedactionLogModal = ({
   useEffect(() => {
     const cmsDocumentTypeId = activeDocument?.cmsDocType.documentTypeId;
 
-    if (cmsDocumentTypeId === undefined || cmsDocumentTypeId === null) {
+    if (!cmsDocumentTypeId) {
       return;
     }
 
@@ -147,10 +147,6 @@ export const RedactionLogModal = ({
     );
 
     if (!documentTypeIdValue) {
-      return;
-    }
-
-    if (`${form.getValues('documentTypeId')}` === documentTypeIdValue) {
       return;
     }
 

--- a/materials_ui/src/materials_components/RedactionLog/RedactionLogModalHeader.tsx
+++ b/materials_ui/src/materials_components/RedactionLog/RedactionLogModalHeader.tsx
@@ -29,10 +29,6 @@ export const RedactionLogModalHeader = ({
     formState: { errors }
   } = useFormContext<RedactionLogFormInputs>();
 
-  const documentTypes = (lookups?.documentTypes ?? [])
-    .filter((dt) => dt.cmsDocTypeId !== '')
-    .map((dt) => ({ id: dt.cmsDocTypeId.toString(), name: dt.name }));
-
   if (errors.areasAndDivisionsId) {
     errors.areasAndDivisionsId.message =
       'Please enter valid CPS Area or Central Casework Division';
@@ -194,7 +190,7 @@ export const RedactionLogModalHeader = ({
               label="Document Type: "
               id="document-type-select"
               name={field.name}
-              options={documentTypes}
+              options={lookups?.documentTypes ?? []}
               value={field.value}
               onChange={(e) => field.onChange(e.target.value)}
             />

--- a/materials_ui/src/materials_components/RedactionLog/templates/ErrorSummary.tsx
+++ b/materials_ui/src/materials_components/RedactionLog/templates/ErrorSummary.tsx
@@ -6,6 +6,7 @@ export const ErrorSummary = ({
 }: {
   errors: FieldErrors<RedactionLogFormValues>;
 }) => {
+  console.log({ errors });
   if (Object.keys(errors).length === 0) return null;
 
   return (

--- a/materials_ui/src/materials_components/RedactionLog/templates/ErrorSummary.tsx
+++ b/materials_ui/src/materials_components/RedactionLog/templates/ErrorSummary.tsx
@@ -6,7 +6,6 @@ export const ErrorSummary = ({
 }: {
   errors: FieldErrors<RedactionLogFormValues>;
 }) => {
-  console.log({ errors });
   if (Object.keys(errors).length === 0) return null;
 
   return (

--- a/materials_ui/src/materials_components/RedactionLog/utils/getDocumentTypeValueFromMappings.ts
+++ b/materials_ui/src/materials_components/RedactionLog/utils/getDocumentTypeValueFromMappings.ts
@@ -7,8 +7,8 @@ export type RedactionLogMappingData = {
   }[];
 };
 
-const MANUALLY_SELECT_DOCUMENT_TYPE_IDS = [-1, 1029, 1200];
-const DEFENDANT_CATEGORY_DOCUMENT_TYPE_IDS = [1056, 1057];
+const MANUALLY_SELECT_DOCUMENT_TYPE_IDS = new Set([-1, 1029, 1200]);
+const DEFENDANT_CATEGORY_DOCUMENT_TYPE_IDS = new Set([1056, 1057]);
 const PNC_PRINT_DOCUMENT_TYPE_ID = '34';
 
 export function getDocumentTypeValueFromMappings(
@@ -16,17 +16,17 @@ export function getDocumentTypeValueFromMappings(
   documentTypeMappings: RedactionLogMappingData | null | undefined
 ): string | undefined {
   const documentIsManuallySelected =
-    MANUALLY_SELECT_DOCUMENT_TYPE_IDS.includes(documentTypeId);
+    MANUALLY_SELECT_DOCUMENT_TYPE_IDS.has(documentTypeId);
 
   const currentDocumentType = documentTypeMappings?.documentTypes.find(
     ({ cmsDocTypeId }) => cmsDocTypeId === `${documentTypeId}`
   );
 
   if (documentIsManuallySelected || !currentDocumentType?.docTypeId) {
-    return undefined;
+    return;
   }
 
-  if (DEFENDANT_CATEGORY_DOCUMENT_TYPE_IDS.includes(documentTypeId)) {
+  if (DEFENDANT_CATEGORY_DOCUMENT_TYPE_IDS.has(documentTypeId)) {
     return PNC_PRINT_DOCUMENT_TYPE_ID;
   }
 

--- a/materials_ui/src/materials_components/RedactionLog/utils/getDocumentTypeValueFromMappings.ts
+++ b/materials_ui/src/materials_components/RedactionLog/utils/getDocumentTypeValueFromMappings.ts
@@ -1,0 +1,34 @@
+export type RedactionLogMappingData = {
+  businessUnits: { ou: string; areaId: string | null; unitId: string | null }[];
+  documentTypes: { cmsDocTypeId: string; docTypeId: string }[];
+  investigatingAgencies: {
+    ouCode: string;
+    investigatingAgencyId: string | null;
+  }[];
+};
+
+const MANUALLY_SELECT_DOCUMENT_TYPE_IDS = [-1, 1029, 1200];
+const DEFENDANT_CATEGORY_DOCUMENT_TYPE_IDS = [1056, 1057];
+const PNC_PRINT_DOCUMENT_TYPE_ID = '34';
+
+export function getDocumentTypeValueFromMappings(
+  documentTypeId: number,
+  documentTypeMappings: RedactionLogMappingData | null | undefined
+): string | undefined {
+  const documentIsManuallySelected =
+    MANUALLY_SELECT_DOCUMENT_TYPE_IDS.includes(documentTypeId);
+
+  const currentDocumentType = documentTypeMappings?.documentTypes.find(
+    ({ cmsDocTypeId }) => cmsDocTypeId === `${documentTypeId}`
+  );
+
+  if (documentIsManuallySelected || !currentDocumentType?.docTypeId) {
+    return undefined;
+  }
+
+  if (DEFENDANT_CATEGORY_DOCUMENT_TYPE_IDS.includes(documentTypeId)) {
+    return PNC_PRINT_DOCUMENT_TYPE_ID;
+  }
+
+  return currentDocumentType.docTypeId;
+}

--- a/materials_ui/src/materials_components/RedactionLog/utils/getDocumentTypeValueFromMappings.ts
+++ b/materials_ui/src/materials_components/RedactionLog/utils/getDocumentTypeValueFromMappings.ts
@@ -13,7 +13,7 @@ const PNC_PRINT_DOCUMENT_TYPE_ID = '34';
 
 export function getDocumentTypeValueFromMappings(
   documentTypeId: number,
-  documentTypeMappings: RedactionLogMappingData | null | undefined
+  documentTypeMappings: RedactionLogMappingData | null
 ): string | undefined {
   const documentIsManuallySelected =
     MANUALLY_SELECT_DOCUMENT_TYPE_IDS.has(documentTypeId);

--- a/materials_ui/src/materials_components/RedactionLog/utils/transformFormData.ts
+++ b/materials_ui/src/materials_components/RedactionLog/utils/transformFormData.ts
@@ -4,6 +4,15 @@ import { TDocument } from '../../DocumentSelectAccordion/getters/getDocumentList
 import { TRedactionType } from '../../PdfRedactor/PdfRedactionTypeForm';
 import { RedactionLogFormInputs } from '../RedactionLogModal';
 
+type TransformFormDataToApiFormatParams = {
+  formData: RedactionLogFormInputs;
+  urn: string;
+  activeDocument: TDocument | null | undefined;
+  lookups: TLookupsResponse | undefined;
+  mode: 'over-under' | 'list';
+  listModeRedactionTypes: TRedactionType[];
+};
+
 const normalize = (value: string | number | undefined | null): string =>
   value === undefined || value === null ? '' : value.toString().trim();
 
@@ -94,15 +103,6 @@ const createListModeRedactions = (
     returnedToInvestigativeAuthority: false
   }));
 
-type TransformFormDataToApiFormatParams = {
-  formData: RedactionLogFormInputs;
-  urn: string;
-  activeDocument: TDocument | null | undefined;
-  lookups: TLookupsResponse | undefined;
-  mode: 'over-under' | 'list';
-  listModeRedactionTypes: TRedactionType[];
-};
-
 export const transformFormDataToApiFormat = ({
   formData,
   urn,
@@ -126,9 +126,8 @@ export const transformFormDataToApiFormat = ({
   );
 
   const documentType = lookups.documentTypes?.find(
-    (dt) =>
-      normalize(dt.cmsDocTypeId) &&
-      normalize(dt.cmsDocTypeId) === normalize(formData.documentTypeId)
+    (documentType) =>
+      normalize(documentType.id) === normalize(formData.documentTypeId)
   );
 
   const redactions =
@@ -154,9 +153,7 @@ export const transformFormDataToApiFormat = ({
       name: investigatingAgency?.name || ''
     },
     documentType: {
-      id:
-        normalize(documentType?.cmsDocTypeId) ??
-        normalize(formData.documentTypeId),
+      id: documentType?.id || normalize(formData.documentTypeId),
       name: documentType?.name || ''
     },
     redactions,
@@ -167,10 +164,10 @@ export const transformFormDataToApiFormat = ({
       documentId: activeDocument?.documentId
         ? activeDocument.documentId.replace(/^CMS-/, '')
         : 0,
-      documentType: documentType?.name || '',
+      documentType: activeDocument?.cmsDocType.documentType || '',
       fileCreatedDate:
         activeDocument?.cmsFileCreatedDate || new Date().toISOString(),
-      documentTypeId: parseInt(normalize(formData.documentTypeId) || '0', 10)
+      documentTypeId: activeDocument?.cmsDocType.documentTypeId || 0
     }
   };
 };

--- a/materials_ui/src/materials_components/RedactionLog/utils/transformFormData.ts
+++ b/materials_ui/src/materials_components/RedactionLog/utils/transformFormData.ts
@@ -4,16 +4,9 @@ import { TDocument } from '../../DocumentSelectAccordion/getters/getDocumentList
 import { TRedactionType } from '../../PdfRedactor/PdfRedactionTypeForm';
 import { RedactionLogFormInputs } from '../RedactionLogModal';
 
-type TransformFormDataToApiFormatParams = {
-  formData: RedactionLogFormInputs;
-  urn: string;
-  activeDocument: TDocument | null | undefined;
-  lookups: TLookupsResponse | undefined;
-  mode: 'over-under' | 'list';
-  listModeRedactionTypes: TRedactionType[];
-};
-
-const normalize = (value: string | number | undefined | null): string =>
+const normalizeToString = (
+  value: string | number | undefined | null
+): string =>
   value === undefined || value === null ? '' : value.toString().trim();
 
 const findAreaAndUnit = (
@@ -21,16 +14,18 @@ const findAreaAndUnit = (
   areaId: string,
   unitId: string
 ) => {
-  const normalizedAreaId = normalize(areaId);
-  const normalizedUnitId = normalize(unitId);
+  const trimmedAreaId = normalizeToString(areaId);
+  const trimmedUnitId = normalizeToString(unitId);
 
   for (const area of lookups.areas || []) {
     if (
-      normalize(area.id) === normalizedAreaId &&
-      area.children?.some((child) => normalize(child.id) === normalizedUnitId)
+      normalizeToString(area.id) === trimmedAreaId &&
+      area.children?.some(
+        (child) => normalizeToString(child.id) === trimmedUnitId
+      )
     ) {
       const unit = area.children?.find(
-        (child) => normalize(child.id) === normalizedUnitId
+        (child) => normalizeToString(child.id) === trimmedUnitId
       );
       return { area, unit };
     }
@@ -38,13 +33,13 @@ const findAreaAndUnit = (
 
   for (const division of lookups.divisions || []) {
     if (
-      normalize(division.id) === normalizedAreaId &&
+      normalizeToString(division.id) === trimmedAreaId &&
       division.children?.some(
-        (child) => normalize(child.id) === normalizedUnitId
+        (child) => normalizeToString(child.id) === trimmedUnitId
       )
     ) {
       const unit = division.children?.find(
-        (child) => normalize(child.id) === normalizedUnitId
+        (child) => normalizeToString(child.id) === trimmedUnitId
       );
       return { area: division, unit };
     }
@@ -64,7 +59,7 @@ const createOverUnderModeRedactions = (
 
   const findRedactionType = (typeId: number) =>
     lookups.missedRedactions?.find(
-      (rt) => normalize(rt.id) === normalize(typeId)
+      (rt) => normalizeToString(rt.id) === normalizeToString(typeId)
     );
 
   // under redactions
@@ -103,6 +98,15 @@ const createListModeRedactions = (
     returnedToInvestigativeAuthority: false
   }));
 
+type TransformFormDataToApiFormatParams = {
+  formData: RedactionLogFormInputs;
+  urn: string;
+  activeDocument: TDocument | null | undefined;
+  lookups: TLookupsResponse | undefined;
+  mode: 'over-under' | 'list';
+  listModeRedactionTypes: TRedactionType[];
+};
+
 export const transformFormDataToApiFormat = ({
   formData,
   urn,
@@ -122,12 +126,16 @@ export const transformFormDataToApiFormat = ({
   );
 
   const investigatingAgency = lookups.investigatingAgencies?.find(
-    (ia) => normalize(ia.id) === normalize(formData.investigatingAgencyId)
+    (ia) =>
+      normalizeToString(ia.id) ===
+      normalizeToString(formData.investigatingAgencyId)
   );
 
   const documentType = lookups.documentTypes?.find(
-    (documentType) =>
-      normalize(documentType.id) === normalize(formData.documentTypeId)
+    (dt) =>
+      normalizeToString(dt.cmsDocTypeId) &&
+      normalizeToString(dt.cmsDocTypeId) ===
+        normalizeToString(formData.documentTypeId)
   );
 
   const redactions =
@@ -153,7 +161,7 @@ export const transformFormDataToApiFormat = ({
       name: investigatingAgency?.name || ''
     },
     documentType: {
-      id: documentType?.id || normalize(formData.documentTypeId),
+      id: documentType?.id || normalizeToString(formData.documentTypeId),
       name: documentType?.name || ''
     },
     redactions,


### PR DESCRIPTION
Mirroring what we have in Polaris UI to attain parity. Introduced polaris mapping endpoint to properly map the document type