### PR TITLE
chore/prettier-printWidth

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,10 @@
 {
   "singleQuote": true,
-  "trailingComma": "none",
+  "trailingComma": "all",
   "objectWrap": "collapse",
   "semi": true,
   "useTabs": false,
   "bracketSpacing": true,
+  "printWidth": 100,
   "endOfLine": "crlf"
 }

--- a/materials_ui/.prettierrc
+++ b/materials_ui/.prettierrc
@@ -6,5 +6,6 @@
   "semi": true,
   "useTabs": false,
   "bracketSpacing": true,
+  "printWidth": 100,
   "endOfLine": "crlf"
 }


### PR DESCRIPTION
Increase print width by 20 to improve JSX readability - I've been using this on my side projects for a while now and find that it is a nice dev experience improvement


<img width="2256" height="1432" alt="image" src="https://github.com/user-attachments/assets/2affd6d8-0202-41bb-bf69-05033164ac17" />


<img width="2256" height="1432" alt="image" src="https://github.com/user-attachments/assets/d857e7ea-0b3f-4e90-a083-9bc6049fbec2" />
