### PR TITLE
FCT2-18151: fix(redaction-log): resolve document type name on save

### DIFF
--- a/materials_ui/src/materials_components/RedactionLog/RedactionLogModal.tsx
+++ b/materials_ui/src/materials_components/RedactionLog/RedactionLogModal.tsx
@@ -168,17 +168,11 @@ export const RedactionLogModal = ({
         listModeRedactionTypes: selectedRedactionTypes
       });
 
-      // TODO: ensure documentType values are taken from the dropdown selection
-      // and propagated into apiData.documentType and apiData.cmsValues.
-      // This is required to avoid API validation errors: DocumentType.Name is required.
-      console.log('Submitting redaction log:', apiData);
-
       await postRedactionLog({
         axiosInstance: redactionLogAxios,
         data: apiData
       });
 
-      console.log('Redaction log submitted successfully');
       onClose();
     } catch (error) {
       console.error('Failed to submit redaction log:', error);

--- a/materials_ui/src/materials_components/RedactionLog/utils/transformFormData.ts
+++ b/materials_ui/src/materials_components/RedactionLog/utils/transformFormData.ts
@@ -133,9 +133,8 @@ export const transformFormDataToApiFormat = ({
 
   const documentType = lookups.documentTypes?.find(
     (dt) =>
-      normalizeToString(dt.cmsDocTypeId) &&
-      normalizeToString(dt.cmsDocTypeId) ===
-        normalizeToString(formData.documentTypeId)
+      normalizeToString(dt.id) &&
+      normalizeToString(dt.id) === normalizeToString(formData.documentTypeId)
   );
 
   const redactions =


### PR DESCRIPTION
The Document Type dropdown stores lookup id values, but transformFormDataToApiFormat matched cmsDocTypeId instead, so manual selections never resolved name and the API rejected empty DocumentType.Name. Match on id to align with SelectDropdown.

Remove obsolete TODO and debug logging from RedactionLogModal.