### PR TITLE
FCT2-18275 standardise completed action status tags

### DIFF
--- a/materials_ui/src/App.scss
+++ b/materials_ui/src/App.scss
@@ -247,8 +247,7 @@ strong {
   margin-bottom: 0;
 }
 
-.reclassified-tag,
-.renamed-tag {
+.successful-tag {
   font-size: 14px;
   padding: 4px;
   line-height: 1;
@@ -390,45 +389,6 @@ strong {
   padding: 4px;
   line-height: 1;
   margin: 0px 8px 0px 0px;
-}
-
-.action-bar-container {
-  display: flex;
-  margin-bottom: 10px;
-  justify-content: flex-end;
-  padding: 10px 20px 10px 0;
-  gap: 12px;
-}
-
-.divider {
-  width: 1px;
-  background-color: #b1b4b6;
-  height: 20px;
-  margin: 0 12px;
-  align-self: center;
-}
-
-.new-tag {
-  font-size: 14px;
-  padding: 4px;
-  line-height: 1;
-  margin: 0 8px 0 0;
-}
-
-.action-bar-container {
-  display: flex;
-  margin-bottom: 10px;
-  justify-content: flex-end;
-  padding: 10px 20px 10px 0;
-  gap: 12px;
-}
-
-.divider {
-  width: 1px;
-  background-color: #b1b4b6;
-  height: 20px;
-  margin: 0 12px;
-  align-self: center;
 }
 
 .govuk-table--width-fluid {

--- a/materials_ui/src/components/StatusTag/StatusTag.tsx
+++ b/materials_ui/src/components/StatusTag/StatusTag.tsx
@@ -18,10 +18,9 @@ export const StatusTag = ({ status }: Props) => {
       className += ' govuk-tag--grey';
       break;
     case 'Reclassified':
-      className += ' govuk-tag--purple reclassified-tag';
-      break;
     case 'Renamed':
-      className += ' govuk-tag--green renamed-tag';
+    case 'Updated':
+      className += ' govuk-tag--green successful-tag';
       break;
     case 'New':
       className += ' govuk-tag--blue new-tag';


### PR DESCRIPTION
[FCT2-18275](https://cpsgovuk.atlassian.net/browse/FCT2-18275)
Use a shared success style for updated, reclassified, and renamed materials so completed actions render consistently. Remove unused duplicate action bar styles while keeping the tag styling focused on the shared completed state.

<img width="843" height="124" alt="image" src="https://github.com/user-attachments/assets/08e154c0-dbc6-46fa-9620-e500946fce6c" />
<img width="741" height="127" alt="image" src="https://github.com/user-attachments/assets/daaa9663-f2b0-41f6-8b9e-d7f4566d292e" />
<img width="700" height="126" alt="image" src="https://github.com/user-attachments/assets/562cee0e-3492-4c96-88f0-f9c4d986e8b5" />

