### PR TITLE
feat(tracking): track user actions, roles and time in telemetry

### DIFF
--- a/materials_ui/src/app.tsx
+++ b/materials_ui/src/app.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { RouteChangeListener } from './components';
 import { loginRequest } from './msalInstance';
 import { Routes } from './routes';
+import { setTelemetryUserRole } from './telemetry/appInsights';
 
 export const App = () => {
   const { instance, accounts } = useMsal();
@@ -14,6 +15,13 @@ export const App = () => {
   }, [instance, accounts]);
 
   const account = instance.getActiveAccount() || accounts[0];
+  const role = (account?.idTokenClaims?.roles as string[] | undefined)?.join(
+    ','
+  );
+
+  useEffect(() => {
+    if (role) setTelemetryUserRole(role);
+  }, [role]);
 
   if (!account) {
     return <p>Redirecting to login...</p>;

--- a/materials_ui/src/caseWorkApp/pages/ReviewAndRedactPage/ReviewAndRedactPage.tsx
+++ b/materials_ui/src/caseWorkApp/pages/ReviewAndRedactPage/ReviewAndRedactPage.tsx
@@ -31,6 +31,7 @@ import { convertMatchesToSearchHighlights } from '../../../materials_components/
 import { useTrigger } from '../../../materials_components/PdfRedactor/utils/useTriggger';
 import { RedactionLogModal } from '../../../materials_components/RedactionLog/RedactionLogModal';
 import type { SearchTermResultType } from '../../../schemas/documents';
+import { trackAction, trackMetric } from '../../../telemetry/appInsights';
 import { Tabs } from '../../components/tabs';
 import { getLookups, useAxiosInstances } from '../../components/utils/getData';
 import { useSwitchContentArea } from '../../hooks/useSwitchContentArea';
@@ -365,6 +366,12 @@ export const ReviewAndRedactPage = () => {
 
   const activeTabId = activeParentId || openParentIds[0] || '';
 
+  useEffect(() => {
+    if (!activeTabId) return;
+    const start = Date.now();
+    return () => trackMetric('TabViewTime', Date.now() - start);
+  }, [activeTabId]);
+
   const activeDocument = openDocuments.find(
     (doc) => doc.parentId === activeTabId
   );
@@ -504,6 +511,9 @@ export const ReviewAndRedactPage = () => {
                   onRedactionLogClick={() => setShowRedactionLogModal(true)}
                   onViewInNewWindowClick={() => {
                     if (!urn || !caseId) return;
+                    trackAction('OpenedInNewWindow', {
+                      materialId: activeTabId
+                    });
                     navigateToViewDocumentPageInNewTab({
                       urn,
                       caseId,

--- a/materials_ui/src/components/Button/AutoReclassifyButton.tsx
+++ b/materials_ui/src/components/Button/AutoReclassifyButton.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { useAutoReclassify, useBanner, useCaseMaterials } from '../../hooks';
 import { useMaterialTags } from '../../stores';
+import { trackAction } from '../../telemetry/appInsights';
 
 export const AutoReclassifyButton = () => {
   const [errorCount, setErrorCount] = useState(0);
@@ -45,6 +46,7 @@ export const AutoReclassifyButton = () => {
     },
     onSuccess: async (data) => {
       const totalMaterialsProcessed = data.reclassifiedMaterials.length || 1;
+      trackAction('UpdatedAutomatically', { count: totalMaterialsProcessed });
 
       setTags(
         data?.reclassifiedMaterials?.map((material) => ({

--- a/materials_ui/src/components/Drawer/RenameDrawer.tsx
+++ b/materials_ui/src/components/Drawer/RenameDrawer.tsx
@@ -18,7 +18,7 @@ export const RenameDrawer = ({ material, onCancel, onSuccess }: Props) => {
       trackAction('Renamed', {
         materialId:
           material && 'materialId' in material
-            ? material.materialId
+            ? material.materialId?.toString()
             : undefined,
         category:
           material && 'category' in material ? material.category : undefined

--- a/materials_ui/src/components/Drawer/RenameDrawer.tsx
+++ b/materials_ui/src/components/Drawer/RenameDrawer.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, FormEvent, useState } from 'react';
 import { useRename } from '../../hooks';
 import { TDocument } from '../../materials_components/DocumentSelectAccordion/getters/getDocumentList';
 import { CaseMaterialsType } from '../../schemas';
+import { trackAction } from '../../telemetry/appInsights';
 import { LoadingSpinner } from '../LoadingSpinner/LoadingSpinner';
 import Drawer from './Drawer';
 
@@ -13,7 +14,17 @@ type Props = {
 
 export const RenameDrawer = ({ material, onCancel, onSuccess }: Props) => {
   const { isMutating, trigger: renameMaterial } = useRename(material, {
-    onSuccess
+    onSuccess: () => {
+      trackAction('Renamed', {
+        materialId:
+          material && 'materialId' in material
+            ? material.materialId
+            : undefined,
+        category:
+          material && 'category' in material ? material.category : undefined
+      });
+      onSuccess();
+    }
   });
   const [error, setError] = useState<string>('');
 

--- a/materials_ui/src/materials_components/CaseworkPdfRedactorWrapper/CaseworkPdfRedactorWrapper.tsx
+++ b/materials_ui/src/materials_components/CaseworkPdfRedactorWrapper/CaseworkPdfRedactorWrapper.tsx
@@ -1,5 +1,6 @@
 import { ComponentProps, useEffect, useState } from 'react';
 import { Button } from '../../caseWorkApp/components/button';
+import { trackAction } from '../../telemetry/appInsights';
 import { useAxiosInstance } from '../DocumentSelectAccordion/getters/getAxiosInstance';
 import { TDocument } from '../DocumentSelectAccordion/getters/getDocumentList';
 import { GovUkBanner } from '../DocumentSelectAccordion/templates/GovUkBanner';
@@ -404,6 +405,7 @@ export const CaseworkPdfRedactorWrapper = (p: {
               redactions
             });
             setRedactions([]);
+            trackAction('Redacted', { materialId: p.parentId });
             p.onRedactionSaveStatusChange('saved');
             if (p.document) p.onModification(p.document);
             await documentCheckOutRequest.checkIn({

--- a/materials_ui/src/pages/Communications.tsx
+++ b/materials_ui/src/pages/Communications.tsx
@@ -25,6 +25,7 @@ import {
   useMaterialTags,
   useSelectedItemsStore
 } from '../stores';
+import { trackAction } from '../telemetry/appInsights';
 
 export const CommunicationsPage = () => {
   const [selectedMaterial, setSelectedMaterial] =
@@ -95,6 +96,10 @@ export const CommunicationsPage = () => {
     const caseId = caseInfo?.id;
     if (!materialId || !urn || !caseId) return;
 
+    trackAction('OpenedInNewWindow', {
+      materialId: row?.materialId,
+      category: row?.category
+    });
     navigateToViewDocumentPageInNewTab({ urn, caseId, materialId });
   };
 

--- a/materials_ui/src/pages/Communications.tsx
+++ b/materials_ui/src/pages/Communications.tsx
@@ -97,7 +97,7 @@ export const CommunicationsPage = () => {
     if (!materialId || !urn || !caseId) return;
 
     trackAction('OpenedInNewWindow', {
-      materialId: row?.materialId,
+      materialId: row?.materialId?.toString(),
       category: row?.category
     });
     navigateToViewDocumentPageInNewTab({ urn, caseId, materialId });

--- a/materials_ui/src/pages/DiscardMaterial.tsx
+++ b/materials_ui/src/pages/DiscardMaterial.tsx
@@ -26,7 +26,7 @@ export const DiscardMaterialPage = () => {
   const { isLoading: isDiscarding, trigger } = useDiscard(material, {
     onSuccess: async () => {
       trackAction('Discarded', {
-        materialId: material?.materialId,
+        materialId: material?.materialId?.toString(),
         category: material?.category
       });
       setError('');

--- a/materials_ui/src/pages/DiscardMaterial.tsx
+++ b/materials_ui/src/pages/DiscardMaterial.tsx
@@ -5,6 +5,7 @@ import { DISCARD_MATERIAL_OPTIONS } from '../constants';
 import { Layout, LoadingSpinner, RadioOption, Radios } from '../components';
 import { URL } from '../constants/url';
 import { useAppRoute, useBanner, useCaseMaterials, useDiscard } from '../hooks';
+import { trackAction } from '../telemetry/appInsights';
 
 export const DiscardMaterialPage = () => {
   const { getRoute } = useAppRoute();
@@ -24,6 +25,10 @@ export const DiscardMaterialPage = () => {
 
   const { isLoading: isDiscarding, trigger } = useDiscard(material, {
     onSuccess: async () => {
+      trackAction('Discarded', {
+        materialId: material?.materialId,
+        category: material?.category
+      });
       setError('');
 
       navigate(returnTo, { state: { persistBanner: true } });
@@ -79,56 +84,56 @@ export const DiscardMaterialPage = () => {
     <>
       <LoadingSpinner isLoading={isDiscarding} />
       {!isDiscarding && (
-    <Layout plain title="Discard Material">
-      <Link
-        to={returnTo}
-        onClick={(e) => {
-          e.preventDefault();
-          navigate(-1);
-        }}
-        className="govuk-back-link"
-      >
-        Back
-      </Link>
+        <Layout plain title="Discard Material">
+          <Link
+            to={returnTo}
+            onClick={(e) => {
+              e.preventDefault();
+              navigate(-1);
+            }}
+            className="govuk-back-link"
+          >
+            Back
+          </Link>
 
-      <div className="govuk-main-wrapper">
-        <h2 className="govuk-caption-l hmrc-caption-l">
-          <span className="govuk-visually-hidden">This section is </span>Discard
-          material
-        </h2>
-        <h1 className="govuk-heading-l">Reason for discarding material</h1>
+          <div className="govuk-main-wrapper">
+            <h2 className="govuk-caption-l hmrc-caption-l">
+              <span className="govuk-visually-hidden">This section is </span>
+              Discard material
+            </h2>
+            <h1 className="govuk-heading-l">Reason for discarding material</h1>
 
-        <form onSubmit={handleSubmit}>
-          <Radios
-            error={error}
-            legend="Select a reason for discarding material"
-            name="reason"
-            onChange={handleRadioChange}
-            options={DISCARD_MATERIAL_OPTIONS.map((option) => ({
-              ...option,
-              id: option.value
-            }))}
-            value={reason?.value as string}
-            required
-          />
+            <form onSubmit={handleSubmit}>
+              <Radios
+                error={error}
+                legend="Select a reason for discarding material"
+                name="reason"
+                onChange={handleRadioChange}
+                options={DISCARD_MATERIAL_OPTIONS.map((option) => ({
+                  ...option,
+                  id: option.value
+                }))}
+                value={reason?.value as string}
+                required
+              />
 
-          <div className="govuk-button-group">
-            <button
-              type="submit"
-              className="govuk-button"
-              data-module="govuk-button"
-              onClick={() => null}
-              data-testid="saveChangesButton"
-            >
-              Save and discard
-            </button>
-            <Link to={returnTo} className="govuk-link cancel-status-change">
-              Cancel
-            </Link>
+              <div className="govuk-button-group">
+                <button
+                  type="submit"
+                  className="govuk-button"
+                  data-module="govuk-button"
+                  onClick={() => null}
+                  data-testid="saveChangesButton"
+                >
+                  Save and discard
+                </button>
+                <Link to={returnTo} className="govuk-link cancel-status-change">
+                  Cancel
+                </Link>
+              </div>
+            </form>
           </div>
-        </form>
-      </div>
-    </Layout>
+        </Layout>
       )}
     </>
   );

--- a/materials_ui/src/pages/DiscardMaterial.tsx
+++ b/materials_ui/src/pages/DiscardMaterial.tsx
@@ -98,7 +98,7 @@ export const DiscardMaterialPage = () => {
 
           <div className="govuk-main-wrapper">
             <h2 className="govuk-caption-l hmrc-caption-l">
-              <span className="govuk-visually-hidden">This section is </span>
+              <span className="govuk-visually-hidden">This section is</span>{' '}
               Discard material
             </h2>
             <h1 className="govuk-heading-l">Reason for discarding material</h1>

--- a/materials_ui/src/pages/EditMaterial.tsx
+++ b/materials_ui/src/pages/EditMaterial.tsx
@@ -48,7 +48,7 @@ export const EditMaterialPage = () => {
     },
     onSuccess: (response) => {
       trackAction('Updated', {
-        materialId: row?.materialId,
+        materialId: row?.materialId?.toString(),
         category: row?.category
       });
       setTags([{ materialId: response?.materialId, tagName: 'Updated' }]);

--- a/materials_ui/src/pages/EditMaterial.tsx
+++ b/materials_ui/src/pages/EditMaterial.tsx
@@ -19,6 +19,7 @@ import {
   EditStatementType
 } from '../schemas/forms/editStatement';
 import { useMaterialTags } from '../stores';
+import { trackAction } from '../telemetry/appInsights';
 
 type EditMaterialLocationState = { returnTo: string; row: CaseMaterialsType };
 type FormStep = 'form' | 'summary';
@@ -46,6 +47,10 @@ export const EditMaterialPage = () => {
       });
     },
     onSuccess: (response) => {
+      trackAction('Updated', {
+        materialId: row?.materialId,
+        category: row?.category
+      });
       setTags([{ materialId: response?.materialId, tagName: 'Updated' }]);
       setBanner(
         {

--- a/materials_ui/src/pages/Materials.tsx
+++ b/materials_ui/src/pages/Materials.tsx
@@ -111,7 +111,10 @@ export const MaterialsPage = () => {
       const urn = caseInfo?.urn;
       const caseId = caseInfo?.id;
       if (!urn || !caseId) return;
-      trackAction('OpenedInNewWindow', { materialId, category: item.category });
+      trackAction('OpenedInNewWindow', {
+        materialId: materialId.toString(),
+        category: item.category
+      });
       navigateToViewDocumentPageInNewTab({ urn, caseId, materialId });
     }
   };

--- a/materials_ui/src/pages/Materials.tsx
+++ b/materials_ui/src/pages/Materials.tsx
@@ -28,6 +28,7 @@ import { useNavigate } from 'react-router-dom';
 import { URL } from '../constants/url';
 import { navigateToViewDocumentPageInNewTab } from '../hooks/ui/navigateToViewDocumentPageInNewTab';
 import { CaseMaterialsType } from '../schemas';
+import { trackAction } from '../telemetry/appInsights';
 
 export const MaterialsPage = () => {
   const { getRoute } = useAppRoute();
@@ -110,6 +111,7 @@ export const MaterialsPage = () => {
       const urn = caseInfo?.urn;
       const caseId = caseInfo?.id;
       if (!urn || !caseId) return;
+      trackAction('OpenedInNewWindow', { materialId, category: item.category });
       navigateToViewDocumentPageInNewTab({ urn, caseId, materialId });
     }
   };

--- a/materials_ui/src/pages/Reclassification.tsx
+++ b/materials_ui/src/pages/Reclassification.tsx
@@ -32,6 +32,7 @@ import {
   Reclassify_WitnessAndActionPlanType
 } from '../schemas/forms/reclassify';
 import { useMaterialTags } from '../stores';
+import { trackAction } from '../telemetry/appInsights';
 import { formatDate } from '../utils/date';
 import { getBannerData } from '../utils/reclassify';
 
@@ -84,6 +85,10 @@ export const ReclassificationPage = () => {
       });
 
       if (response.data.status !== 'Failed') {
+        trackAction('Reclassified', {
+          materialId: material.materialId,
+          category: material.category
+        });
         const documentType = getDocumentTypeById(fieldValues.documentType);
         const materialReclassifiedId =
           response?.data?.reclassificationResult?.resultData

--- a/materials_ui/src/pages/Reclassification.tsx
+++ b/materials_ui/src/pages/Reclassification.tsx
@@ -86,7 +86,7 @@ export const ReclassificationPage = () => {
 
       if (response.data.status !== 'Failed') {
         trackAction('Reclassified', {
-          materialId: material.materialId,
+          materialId: material.materialId?.toString(),
           category: material.category
         });
         const documentType = getDocumentTypeById(fieldValues.documentType);

--- a/materials_ui/src/telemetry/appInsights.ts
+++ b/materials_ui/src/telemetry/appInsights.ts
@@ -10,9 +10,16 @@ const samplingPercentage =
   Number(import.meta.env.VITE_APPLICATIONINSIGHTS_SAMPLING_PERCENTAGE) || 20;
 
 let appInsights: ApplicationInsights | undefined;
+let userRole: string | undefined;
 
 const normaliseError = (error: unknown): Error =>
   error instanceof Error ? error : new Error(String(error));
+
+// Routes are /:urn/:caseId/... so the raw path carries the case reference and
+// id. Swap those (and any numeric id) for placeholders so we never send case
+// identifiers and page views group by route instead of per case.
+const normalisePath = (path: string): string =>
+  path.replace(/^\/[^/]+\/[^/]+/, '/:urn/:caseId').replace(/\/\d+/g, '/:id');
 
 export const initTelemetry = () => {
   if (appInsights || !connectionString) return;
@@ -21,13 +28,14 @@ export const initTelemetry = () => {
     config: {
       connectionString,
       enableAutoRouteTracking: false,
-      enableUnhandledPromiseRejectionTracking: true
+      enableUnhandledPromiseRejectionTracking: true,
+      autoTrackPageVisitTime: true
     }
   });
   appInsights.loadAppInsights();
 
   // Sample non-exceptions ourselves so we never drop exceptions. One roll per
-  // load keeps a page's telemetry together.
+  // load keeps a page's telemetry together. Actions (events) are kept too.
   const retainNonException = Math.random() * 100 < samplingPercentage;
 
   appInsights.addTelemetryInitializer((item) => {
@@ -36,7 +44,12 @@ export const initTelemetry = () => {
       item.tags['ai.cloud.role'] = cloudRole;
     }
 
-    if (item.baseType === 'ExceptionData') {
+    if (userRole) {
+      item.data ??= {};
+      item.data.userRole = userRole;
+    }
+
+    if (item.baseType === 'ExceptionData' || item.baseType === 'EventData') {
       return true;
     }
 
@@ -44,13 +57,21 @@ export const initTelemetry = () => {
   });
 };
 
+export const setTelemetryUserRole = (role: string) => {
+  userRole = role;
+};
+
 export const trackPageView = (pathname: string) => {
   if (!appInsights) return;
+  const name = normalisePath(pathname);
   // Manual SPA tracking doesn't refresh operation name; it stays on the first
   // page unless we set it ourselves, so telemetry groups under the wrong route.
-  appInsights.context.telemetryTrace.name = pathname;
-  appInsights.trackPageView({ name: pathname });
+  appInsights.context.telemetryTrace.name = name;
+  appInsights.trackPageView({ name });
 };
+
+export const trackAction = (action: string, properties?: ICustomProperties) =>
+  appInsights?.trackEvent({ name: 'UserAction' }, { action, ...properties });
 
 export const trackEvent = (name: string, properties?: ICustomProperties) =>
   appInsights?.trackEvent({ name }, properties);

--- a/materials_ui/src/telemetry/appInsights.ts
+++ b/materials_ui/src/telemetry/appInsights.ts
@@ -15,11 +15,17 @@ let userRole: string | undefined;
 const normaliseError = (error: unknown): Error =>
   error instanceof Error ? error : new Error(String(error));
 
-// Routes are /:urn/:caseId/... so the raw path carries the case reference and
-// id. Swap those (and any numeric id) for placeholders so we never send case
-// identifiers and page views group by route instead of per case.
-const normalisePath = (path: string): string =>
-  path.replace(/^\/[^/]+\/[^/]+/, '/:urn/:caseId').replace(/\/\d+/g, '/:id');
+// A route looks like /<urn>/<caseId>/<page>, sometimes with deeper numeric
+// ids (e.g. /materials/8923052). Those identify a specific case/document, so
+// we replace them with placeholders before sending telemetry: page views then
+// group by route (e.g. /:urn/:caseId/materials) instead of leaking case data.
+const CASE_URN_AND_ID = /^\/[^/]+\/[^/]+/; // leading /<urn>/<caseId>
+const NUMERIC_ID_SEGMENT = /\/\d+/g; // any /<number> segment
+
+const stripCaseIdsFromRoute = (path: string): string =>
+  path
+    .replace(CASE_URN_AND_ID, '/:urn/:caseId')
+    .replace(NUMERIC_ID_SEGMENT, '/:id');
 
 export const initTelemetry = () => {
   if (appInsights || !connectionString) return;
@@ -63,7 +69,7 @@ export const setTelemetryUserRole = (role: string) => {
 
 export const trackPageView = (pathname: string) => {
   if (!appInsights) return;
-  const name = normalisePath(pathname);
+  const name = stripCaseIdsFromRoute(pathname);
   // Manual SPA tracking doesn't refresh operation name; it stays on the first
   // page unless we set it ourselves, so telemetry groups under the wrong route.
   appInsights.context.telemetryTrace.name = name;


### PR DESCRIPTION
- Emit completion-based UserAction events (Reclassified, Updated, Discarded, Renamed, Redacted, UpdatedAutomatically, OpenedInNewWindow) with materialId/category context; View-in-new-window fires on click
- Capture page and per-tab dwell time; stamp MSAL user role on all items
- Sample non-exceptions (default 20%) while keeping exceptions and actions; set cloud role name from env
- Normalise route names to strip case URN/id

<img width="340" height="284" alt="image" src="https://github.com/user-attachments/assets/6bc2db31-968c-49f0-a5d0-72e1dc96f0d8" />
