### PR TITLE
[FCT2-19107] - feat(materials): support private beta usage reporting in App Insights

### DIFF
--- a/materials_ui/src/app.tsx
+++ b/materials_ui/src/app.tsx
@@ -3,7 +3,13 @@ import { useEffect } from 'react';
 import { RouteChangeListener } from './components';
 import { loginRequest } from './msalInstance';
 import { Routes } from './routes';
-import { setTelemetryUserRole } from './telemetry/appInsights';
+import {
+  setTelemetryAuthenticatedUser,
+  setTelemetryUserRole,
+  trackAppOpened,
+} from './telemetry/appInsights';
+
+let appOpenedTracked = false;
 
 export const App = () => {
   const { instance, accounts } = useMsal();
@@ -20,6 +26,18 @@ export const App = () => {
   useEffect(() => {
     if (role) setTelemetryUserRole(role);
   }, [role]);
+
+  const accountId = account?.localAccountId;
+
+  useEffect(() => {
+    if (!accountId) return;
+    // Stamp the signed-in user first so the AppOpened event carries it.
+    setTelemetryAuthenticatedUser(accountId);
+    if (!appOpenedTracked) {
+      appOpenedTracked = true;
+      trackAppOpened();
+    }
+  }, [accountId]);
 
   if (!account) {
     return <p>Redirecting to login...</p>;

--- a/materials_ui/src/telemetry/appInsights.ts
+++ b/materials_ui/src/telemetry/appInsights.ts
@@ -7,6 +7,7 @@ const samplingPercentage =
 
 let appInsights: ApplicationInsights | undefined;
 let userRole: string | undefined;
+let authenticatedUserId: string | undefined;
 
 const normaliseError = (error: unknown): Error =>
   error instanceof Error ? error : new Error(String(error));
@@ -44,6 +45,13 @@ export const initTelemetry = () => {
       item.tags['ai.cloud.role'] = cloudRole;
     }
 
+    // Stamp the signed-in user (MSAL localAccountId, a GUID — no PII) so
+    // reports can count distinct people rather than anonymous browser ids.
+    if (authenticatedUserId) {
+      item.tags ??= {};
+      item.tags['ai.user.authUserId'] = authenticatedUserId;
+    }
+
     if (userRole) {
       item.data ??= {};
       item.data.userRole = userRole;
@@ -61,6 +69,10 @@ export const setTelemetryUserRole = (role: string) => {
   userRole = role;
 };
 
+export const setTelemetryAuthenticatedUser = (id: string) => {
+  authenticatedUserId = id;
+};
+
 export const trackPageView = (pathname: string) => {
   if (!appInsights) return;
   const name = stripCaseIdsFromRoute(pathname);
@@ -72,6 +84,9 @@ export const trackPageView = (pathname: string) => {
 
 export const trackAction = (action: string, properties?: ICustomProperties) =>
   appInsights?.trackEvent({ name: 'UserAction' }, { action, ...properties });
+
+// Once per load; events are not client-sampled (unlike page views / PageVisitTime).
+export const trackAppOpened = () => appInsights?.trackEvent({ name: 'AppOpened' });
 
 export const trackEvent = (name: string, properties?: ICustomProperties) =>
   appInsights?.trackEvent({ name }, properties);


### PR DESCRIPTION
Emit `AppOpened `once per app load and stamp MSAL `localAccountId `on telemetry so weekly reports can count distinct users without `PageVisitTime `sampling bias.