### PR TITLE
FCT2-20793 - fix: enable keyboard navigation on Document actions menu

### DIFF
--- a/materials_ui/src/components/ButtonMenu/_button-menu.scss
+++ b/materials_ui/src/components/ButtonMenu/_button-menu.scss
@@ -54,7 +54,7 @@ $govuk-focus-text-colour: rgb(255, 255, 255);
 }
 
 .moj-button-menu__wrapper {
-  z-index: 10;
+  z-index: 510;
   margin: 5px 0 0;
   padding: 0;
   list-style: none;

--- a/materials_ui/src/materials_components/documenViewportArea/DocumentActionsDropdown.tsx
+++ b/materials_ui/src/materials_components/documenViewportArea/DocumentActionsDropdown.tsx
@@ -1,16 +1,5 @@
-import { useState } from 'react';
-import {
-  DropdownButton2,
-  DropdownListItem,
-} from '../../caseWorkApp/components/dropDownButton/DropdownButton';
+import { ButtonMenuComponent } from '../../components';
 import { TMode } from '../PdfRedactor/utils/modeUtils';
-
-const DROPDOWN_ACTIONS = {
-  LOG_REDACTION: 'log-redaction',
-  ROTATE: 'rotate',
-  DELETE: 'delete',
-  VIEW_NEW_WINDOW: 'view-new-window',
-} as const;
 
 type DocumentActionsDropdownProps = {
   mode: TMode;
@@ -27,59 +16,22 @@ export const DocumentActionsDropdown = ({
   onViewInNewWindowClick,
   numOfDocumentPages,
 }: DocumentActionsDropdownProps) => {
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const menuItems = [
+    { label: 'Log an under/over redaction', onClick: onRedactionLogClick },
+    {
+      label: mode === 'rotation' ? 'Hide rotate document pages' : 'Rotate document pages',
+      onClick: () => onModeChange(mode === 'rotation' ? 'disabled' : 'rotation'),
+    },
+    ...(numOfDocumentPages > 1
+      ? [
+          {
+            label: mode === 'deletion' ? 'Hide delete page options' : 'Show delete page options',
+            onClick: () => onModeChange(mode === 'deletion' ? 'disabled' : 'deletion'),
+          },
+        ]
+      : []),
+    { label: 'View in new window', onClick: onViewInNewWindowClick },
+  ];
 
-  return (
-    <DropdownButton2
-      ariaLabel="document actions dropdown"
-      ButtonContent={<span>Document actions</span>}
-      isOpen={isDropdownOpen}
-      setIsOpen={(x) => setIsDropdownOpen(x)}
-    >
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <DropdownListItem
-          id={DROPDOWN_ACTIONS.LOG_REDACTION}
-          onClick={() => {
-            onRedactionLogClick();
-            setIsDropdownOpen(false);
-          }}
-          borderBottom
-        >
-          Log an Under/Over redaction
-        </DropdownListItem>
-        <DropdownListItem
-          id={DROPDOWN_ACTIONS.ROTATE}
-          borderBottom
-          onClick={() => {
-            onModeChange(mode === 'rotation' ? 'disabled' : 'rotation');
-            setIsDropdownOpen(false);
-          }}
-        >
-          {mode === 'rotation' ? 'Hide rotate document pages' : 'Rotate document pages'}
-        </DropdownListItem>
-        {numOfDocumentPages > 1 && (
-          <DropdownListItem
-            id={DROPDOWN_ACTIONS.DELETE}
-            borderBottom
-            onClick={() => {
-              onModeChange(mode === 'deletion' ? 'disabled' : 'deletion');
-              setIsDropdownOpen(false);
-            }}
-          >
-            {mode === 'deletion' ? 'Hide delete page options' : 'Show delete page options'}
-          </DropdownListItem>
-        )}
-        <DropdownListItem
-          id={DROPDOWN_ACTIONS.VIEW_NEW_WINDOW}
-          borderBottom={false}
-          onClick={() => {
-            onViewInNewWindowClick();
-            setIsDropdownOpen(false);
-          }}
-        >
-          View in new window
-        </DropdownListItem>
-      </div>
-    </DropdownButton2>
-  );
+  return <ButtonMenuComponent menuTitle="Document actions" menuItems={menuItems} />;
 };


### PR DESCRIPTION
Reuse `ButtonMenuComponent` (same pattern as Materials Action on selection) so arrow keys move between items and raise the menu z-index so rotate-page controls no longer cover it.