### PR TITLE
[FCT2-20798] - Fix keyboard focus after case tab navigation

### DIFF
--- a/materials_ui/src/components/Tabs/Tabs.tsx
+++ b/materials_ui/src/components/Tabs/Tabs.tsx
@@ -49,8 +49,8 @@ export const Tabs = ({ tabs }: Props) => {
     if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
 
     event.preventDefault();
-    const shift = event.key === 'ArrowLeft' ? -1 : 1;
-    const nextIndex = (index + shift + tabs.length) % tabs.length;
+    const direction = event.key === 'ArrowLeft' ? -1 : 1;
+    const nextIndex = (index + direction + tabs.length) % tabs.length;
 
     setFocusedTabIndex(nextIndex);
     tabRefs.current[nextIndex]?.focus();

--- a/materials_ui/src/components/Tabs/Tabs.tsx
+++ b/materials_ui/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import { KeyboardEvent, MouseEvent } from 'react';
+import { KeyboardEvent, MouseEvent, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { isPathCurrentUrl } from '../../utils/url';
 import './Tabs.scss';
@@ -17,6 +17,23 @@ export const Tabs = ({ tabs }: Props) => {
   const navigate = useNavigate();
   const location = useLocation();
   const pathname = location.pathname;
+  const selectedTabIndex = tabs.findIndex(
+    (tab) => tab.active || isPathCurrentUrl(pathname, tab.href),
+  );
+  const activeTabIndex = selectedTabIndex === -1 ? 0 : selectedTabIndex;
+  const [focusedTabIndex, setFocusedTabIndex] = useState(activeTabIndex);
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const shouldRestoreTabFocus = Boolean(
+    (location.state as { focusTab?: boolean } | null)?.focusTab,
+  );
+
+  useEffect(() => {
+    setFocusedTabIndex(activeTabIndex);
+
+    if (shouldRestoreTabFocus) {
+      tabRefs.current[activeTabIndex]?.focus();
+    }
+  }, [activeTabIndex, shouldRestoreTabFocus]);
 
   if (tabs.length <= 1) {
     return null;
@@ -25,27 +42,18 @@ export const Tabs = ({ tabs }: Props) => {
   const handleTabClick = (event: MouseEvent, tab: Tab) => {
     event.preventDefault();
 
-    navigate(tab.href, { state: { anchor: 'main-content' } });
+    navigate(tab.href, { state: { focusTab: true } });
   };
 
   const handleKeyboardPress = (event: KeyboardEvent, index: number) => {
-    const key = event.key;
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
 
-    if (key === 'ArrowLeft') {
-      if (index === 0) {
-        return document?.getElementById(`tab-${tabs.length - 1}`)?.focus();
-      } else {
-        return document?.getElementById(`tab-${index - 1}`)?.focus();
-      }
-    }
+    event.preventDefault();
+    const shift = event.key === 'ArrowLeft' ? -1 : 1;
+    const nextIndex = (index + shift + tabs.length) % tabs.length;
 
-    if (key === 'ArrowRight') {
-      if (index === tabs.length - 1) {
-        return document?.getElementById(`tab-0`)?.focus();
-      } else {
-        return document?.getElementById(`tab-${index + 1}`)?.focus();
-      }
-    }
+    setFocusedTabIndex(nextIndex);
+    tabRefs.current[nextIndex]?.focus();
   };
 
   return (
@@ -54,8 +62,7 @@ export const Tabs = ({ tabs }: Props) => {
       <div className="govuk-tabs__list" role="tablist">
         {tabs.map((tab: Tab, index: number) => {
           const { shouldBlockNavigationCheck = () => false } = tab;
-          const isCurrentPage = isPathCurrentUrl(pathname, tab.href);
-          const isActiveAndCurrent = tab.active || isCurrentPage;
+          const isActiveAndCurrent = index === activeTabIndex;
 
           return (
             <button
@@ -74,8 +81,13 @@ export const Tabs = ({ tabs }: Props) => {
               onKeyDown={(event) => {
                 handleKeyboardPress(event, index);
               }}
+              onFocus={() => setFocusedTabIndex(index)}
               role="tab"
               id={`tab-${index}`}
+              ref={(element) => {
+                tabRefs.current[index] = element;
+              }}
+              tabIndex={index === focusedTabIndex ? 0 : -1}
             >
               <span className="govuk-tabs__tab">{tab.name}</span>
             </button>

--- a/materials_ui/src/pages/PcdRequest.tsx
+++ b/materials_ui/src/pages/PcdRequest.tsx
@@ -1,6 +1,6 @@
 import DOMPurify from 'dompurify';
 import { Fragment, useMemo } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Navigate, useLocation, useParams } from 'react-router-dom';
 
 import {
   Accordion,
@@ -18,19 +18,14 @@ import { cleanString } from '../utils/string';
 
 export const PcdRequestPage = () => {
   const { pcdId } = useParams<{ pcdId?: string }>();
-  const navigate = useNavigate();
+  const location = useLocation();
   const { getRoute } = useAppRoute();
   const { data: pcdListData, isLoading: isPcdListLoading } = usePCDList();
-
-  if (!pcdId && pcdListData?.[0]) {
-    navigate(`${pcdListData[0].id}`);
-  }
+  const latestPcdId = !pcdId ? pcdListData?.[0]?.id : undefined;
+  const shouldAutoFocusPageContent = !(location.state as { focusTab?: boolean } | null)?.focusTab;
 
   const { data: pcdDetailsData, isLoading: isPcdDetailsLoading } = usePCD({
-    pcdId: (() => {
-      if (pcdId) return pcdId;
-      if (pcdListData?.[0]) return pcdListData[0].id;
-    })(),
+    pcdId: pcdId ?? latestPcdId,
   });
 
   const navLinks: NavListItem[] | undefined = pcdListData?.map((pcd, index) => ({
@@ -68,6 +63,10 @@ export const PcdRequestPage = () => {
     [pcdDetailsData],
   );
 
+  if (latestPcdId) {
+    return <Navigate to={`${latestPcdId}`} state={location.state} />;
+  }
+
   return (
     <Layout title="PCD Request">
       {/* converting '\n' to actual line breaks with CSS*/}
@@ -75,14 +74,22 @@ export const PcdRequestPage = () => {
         <LoadingSpinner isLoading={isPcdDetailsLoading || isPcdListLoading} />
         {!(isPcdDetailsLoading || isPcdListLoading) &&
           (navLinks?.length === 0 ? (
-            <p className="govuk-body" tabIndex={-1} ref={(el) => el?.focus()}>
+            <p
+              className="govuk-body"
+              tabIndex={-1}
+              ref={shouldAutoFocusPageContent ? (el) => el?.focus() : undefined}
+            >
               There are no PCD Requests to show.
             </p>
           ) : (
             <TwoCol sidebar={renderSidebar()}>
               {pcdDetailsData && (
                 <>
-                  <h1 className="govuk-heading-l" tabIndex={-1} ref={(el) => el?.focus()}>
+                  <h1
+                    className="govuk-heading-l"
+                    tabIndex={-1}
+                    ref={shouldAutoFocusPageContent ? (el) => el?.focus() : undefined}
+                  >
                     {isLatestPcd
                       ? 'Latest PCD Request'
                       : `${formatDate(pcdDetailsData?.decisionRequested)} PCD Request`}

--- a/materials_ui/src/pages/PcdRequest.tsx
+++ b/materials_ui/src/pages/PcdRequest.tsx
@@ -16,6 +16,9 @@ import { useAppRoute, usePCD, usePCDList } from '../hooks';
 import { formatDate } from '../utils/date';
 import { cleanString } from '../utils/string';
 
+const getPcdRequestTitle = (isLatestPcd: boolean, decisionRequested: string) =>
+  isLatestPcd ? 'Latest PCD Request' : `${formatDate(decisionRequested)} PCD Request`;
+
 export const PcdRequestPage = () => {
   const { pcdId } = useParams<{ pcdId?: string }>();
   const location = useLocation();
@@ -90,9 +93,7 @@ export const PcdRequestPage = () => {
                     tabIndex={-1}
                     ref={shouldAutoFocusPageContent ? (el) => el?.focus() : undefined}
                   >
-                    {isLatestPcd
-                      ? 'Latest PCD Request'
-                      : `${formatDate(pcdDetailsData?.decisionRequested)} PCD Request`}
+                    {getPcdRequestTitle(Boolean(isLatestPcd), pcdDetailsData.decisionRequested)}
                   </h1>
                   <DefinitionList
                     items={[


### PR DESCRIPTION
- Add roving keyboard focus to the case navigation tabs
- Restore focus to the selected tab after navigation
- Ensure Tab moves into the page’s left-side content panel
- Prevent PCD Request autofocus from overriding tab focus
