### PR TITLE
FCT2-21246 fix review-redact tests

### DIFF
--- a/materials_ui/tests/tests-e2e/review-redact.spec.ts
+++ b/materials_ui/tests/tests-e2e/review-redact.spec.ts
@@ -4,42 +4,41 @@ import { mockCaseMaterials } from '../mocks/mockCaseMaterials';
 
 test.describe('Review redact page', () => {
   test.beforeEach(async ({ page }) => {
-    // const loadingDocumentHeader = page.getByRole('heading', {
-    //   name: 'Loading documents',
-    //   includeHidden: true,
-    // });
+    const loadingDocumentHeader = page.getByRole('heading', {
+      name: 'Loading Case',
+      includeHidden: true,
+    });
     await mockRoute(page, '/case-materials', mockCaseMaterials());
     await page.goto('./review-and-redact', { waitUntil: 'domcontentloaded' });
     await page.waitForRequest('**/case-info/2167259');
-    // await expect(loadingDocumentHeader).toBeVisible();
-    // await loadingDocumentHeader.waitFor({ state: 'detached' });
+    await expect(loadingDocumentHeader).toBeVisible();
+    await loadingDocumentHeader.waitFor({ state: 'detached' });
+    await page.getByRole('heading', { name: 'Loading Document' }).waitFor({ state: 'detached' });
   });
 
-  // test('T-001: page loads correctly with materials', async ({ page }) => {
-  //   await expect(page.getByRole('searchbox', { name: 'Search within material' })).toBeVisible();
-  //   await expect(page.getByText('Statements')).toBeVisible();
-  //   await expect(page.getByText('Exhibits')).toBeVisible();
-  //   await expect(page.getByText('MG forms')).toBeVisible();
-  //   await expect(page.getByText('Other material')).toBeVisible();
-  //   await expect(page.getByText('Defendant pre-cons')).toBeVisible();
-  //   await expect(page.getByText('Unused material')).toBeVisible();
-  // });
+  test('T-001: page loads correctly with materials', async ({ page }) => {
+    await expect(page.getByRole('searchbox', { name: 'Search within material' })).toBeVisible();
+    await expect(page.getByText('Statements')).toBeVisible();
+    await expect(page.getByText('Exhibits')).toBeVisible();
+    await expect(page.getByText('MG forms')).toBeVisible();
+    await expect(page.getByText('Other material')).toBeVisible();
+    await expect(page.getByText('Defendant pre-cons')).toBeVisible();
+    await expect(page.getByText('Unused material')).toBeVisible();
+  });
 
   test('T-002: If no searches are found messages is displayed to user', async ({ page }) => {
     await mockRoute(page, '/cases/2167259', {});
     await mockRoute(page, '/cases/2167259/tracker', { status: 'Completed', documents: [] });
     await mockRoute(page, '/cases/2167259/search/**', []);
+    await page.getByRole('heading', { name: 'Loading Document' }).waitFor({ state: 'detached' });
 
-    // await expect(page.getByRole('searchbox', { name: 'Search within material' })).toBeVisible();
-    // await page.getByRole('searchbox', { name: 'Search within material' }).fill('test search');
-    // await page
-    //   .getByRole('heading', { name: 'Loading documents', includeHidden: true })
-    //   .waitFor({ state: 'detached' });
-    // await page.getByRole('button', { name: 'Search' }).click();
-    // await page
-    // .getByRole('heading', { name: 'Loading search results', includeHidden: true })
-    // .waitFor({ state: 'detached' });
-    // await expect(page.getByText('No results.')).toBeVisible();
+    await expect(page.getByRole('searchbox', { name: 'Search within material' })).toBeVisible();
+    await page.getByRole('searchbox', { name: 'Search within material' }).fill('test search');
+    await page.getByRole('button', { name: 'Search' }).click();
+    await page
+      .getByRole('heading', { name: 'Loading search results', includeHidden: true })
+      .waitFor({ state: 'detached' });
+    await expect(page.getByText('No results.')).toBeVisible();
   });
 
   test('T-003: User is able to open all sections', async ({ page }) => {


### PR DESCRIPTION
The review and redact tests were failing waiting for documents to load. The default playwright timeout is 5 seconds. This approach insures that the "load document" loading indicator is used as a que such that when it is detached from the DOM the test is able to continue rather then timing out within 5s